### PR TITLE
support WOL on machine with multiple NICS

### DIFF
--- a/braviatv_psk.py
+++ b/braviatv_psk.py
@@ -42,6 +42,7 @@ CONF_PSK = 'psk'
 CONF_AMP = 'amp'
 CONF_ANDROID = 'android'
 CONF_SOURCE_FILTER = 'sourcefilter'
+CONF_BROADCAST = 'broadcast'
 
 # Some additional info to show specific for Sony Bravia TV
 TV_WAIT = 'TV started, waiting for program info'
@@ -55,7 +56,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_AMP, default=False): cv.boolean,
     vol.Optional(CONF_ANDROID, default=False): cv.boolean,
-    vol.Optional(CONF_SOURCE_FILTER, default=[]): vol.All(cv.ensure_list, [cv.string])
+    vol.Optional(CONF_SOURCE_FILTER, default=[]): vol.All(cv.ensure_list, [cv.string]),
+    vol.Optional(CONF_BROADCAST, default="255.255.255.255") : cv.string
 })
 
 # pylint: disable=unused-argument
@@ -68,17 +70,18 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     amp = config.get(CONF_AMP)
     android = config.get(CONF_ANDROID)
     source_filter = config.get(CONF_SOURCE_FILTER)
-
+    broadcast = config.get(CONF_BROADCAST)
+    
     if host is None:
         _LOGGER.error("No TV IP address found in configuration file")
         return
 
-    add_devices([BraviaTVDevice(host, psk, mac, name, amp, android, source_filter)])
+    add_devices([BraviaTVDevice(host, psk, mac, name, amp, android, source_filter,broadcast)])
 
 class BraviaTVDevice(MediaPlayerDevice):
     """Representation of a Sony Bravia TV."""
 
-    def __init__(self, host, psk, mac, name, amp, android, source_filter):
+    def __init__(self, host, psk, mac, name, amp, android, source_filter,broadcast):
         """Initialize the Sony Bravia device."""
         _LOGGER.info("Setting up Sony Bravia TV")
         from braviarc import braviarc_psk
@@ -88,6 +91,7 @@ class BraviaTVDevice(MediaPlayerDevice):
         self._amp = amp
         self._android = android
         self._source_filter = source_filter
+        self._broadcast = broadcast
         self._state = STATE_OFF
         self._muted = False
         self._program_name = None
@@ -274,7 +278,7 @@ class BraviaTVDevice(MediaPlayerDevice):
         if self._android:
             self._braviarc.turn_on_command()
         else:
-            self._braviarc.turn_on()
+            self._braviarc.turn_on(self._broadcast)
 
         # Show info that the TV is starting while no program is yet available
         self._reset_playing_info()


### PR DESCRIPTION
Added config parameter "broadcast" which is send to recently patched braviarc

unsure if 0.4.5 needs to be updated

add:
   broadcast: 10.1.1.255

to the configuration.yaml, parameter is optional and defaults to "255.255.255.255" == "<broadcast>"